### PR TITLE
Warmup for SimCLR Scheduler

### DIFF
--- a/configs/pretrain-medmnist-rn50-1ep.yaml
+++ b/configs/pretrain-medmnist-rn50-1ep.yaml
@@ -25,6 +25,7 @@ Training:
       output_dim: 128
       temperature: 0.07
       n_views: 2
+      warmup: 10
 Logging:
   path: "logs/"
   tool: WANDB

--- a/configs/pretrain-quick-test.yaml
+++ b/configs/pretrain-quick-test.yaml
@@ -26,6 +26,7 @@ Training:
       output_dim: 128
       temperature: 0.07
       n_views: 2
+      warmup: 10
 Logging:
   path: "logs/"
   tool: NONE

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ keras==3.3.3
 lazy_loader==0.4
 libclang==18.1.1
 lightning==2.2.4
+lightning-bolts==0.7.0
 lightning-flash==0.8.2
 lightning-utilities==0.11.2
 Markdown==3.6

--- a/src/ssl/base.py
+++ b/src/ssl/base.py
@@ -19,7 +19,7 @@ import logging
 from src.loader.medmnist_loader import MedMNISTLoader
 from src.utils.config.config import Config
 from src.utils.setup import get_device
-from src.utils.eval import get_auroc_metric, get_representations
+from src.utils.eval import get_representations
 import src.utils.setup as setup
 from medmnist import INFO
 import pytorch_lightning as pl

--- a/src/ssl/simclr/simclr.py
+++ b/src/ssl/simclr/simclr.py
@@ -5,6 +5,7 @@ import pytorch_lightning as pl
 import torch.nn.functional as F
 import torch
 import torchvision.models as models
+from pl_bolts.optimizers.lr_scheduler import LinearWarmupCosineAnnealingLR
 
 from src.ssl.losses import nt_xent
 
@@ -22,6 +23,7 @@ class SimCLR(pl.LightningModule):
         lr,
         max_epochs,
         temperature,
+        warmup,
         cfg_dict = None,
     ):
         """
@@ -76,11 +78,14 @@ class SimCLR(pl.LightningModule):
             lr=self.hparams.lr,
             weight_decay=self.hparams.weight_decay,
         )
-        # Set learning rate using a cosine annealing schedule
-        # See https://pytorch.org/docs/stable/optim.html
-        lr_scheduler = optim.lr_scheduler.CosineAnnealingLR(
+
+        # Set learning rate using a cosine annealing schedule with warmup
+        # See https://pytorch-lightning-bolts.readthedocs.io/en/stable/schedulers/warmup_cosine_annealing.html
+        lr_scheduler = LinearWarmupCosineAnnealingLR(
             optimizer,
-            T_max=self.hparams.max_epochs,
+            warmup_epochs=self.hparams.warmup,
+            max_epochs=self.hparams.max_epochs,
+            warmup_start_lr=0.0,
             eta_min=self.hparams.lr / 50,
         )
 

--- a/src/ssl/simclr/train.py
+++ b/src/ssl/simclr/train.py
@@ -27,6 +27,7 @@ def build_simclr_model(cfg):
         temperature=ssl_params.temperature,
         max_epochs=train_params.max_epochs,
         cfg_dict=cfg.convert_to_dict(),  # So that we can save the cfg
+        warmup=ssl_params.warmup,
     )
 
     return model

--- a/src/utils/config/config.py
+++ b/src/utils/config/config.py
@@ -72,7 +72,7 @@ class Config:
             
             assert _train_cfg.Pretrain.params.hidden_dim > 0
             assert _train_cfg.Pretrain.params.output_dim > 0
-
+            assert _train_cfg.Pretrain.params.warmup >= 0
             assert _train_cfg.Pretrain.params.temperature >= 0
             assert _train_cfg.Pretrain.params.n_views > 0
         else:

--- a/src/utils/config/defaults.yaml
+++ b/src/utils/config/defaults.yaml
@@ -31,6 +31,7 @@ Training:
       output_dim: 128
       temperature: 0.07  # Softmax temperature for contrastive loss
       n_views: 2
+      warmup: 10
   Downstream:
     ssl_method: SIMCLR  # One of SSLMethod
     eval_method: LINEAR  # One of EvalMethod


### PR DESCRIPTION
- Changed scheduler from CosineAnnealingLR to LinearWarmupCosineAnnealingLR (from lighning-bolts) in SimCLR
- Added warmup to config and added the default value of 10
- Added warmup to the example config files
- Added the package "lighning-bolts" to requirements
- Fixed tiny import bug in base.py about auroc
- Added assert statement so that warmup is greater than or equal to 0