### PR TITLE
Hotfix: typo, linear seeding, runner sanity check

### DIFF
--- a/id_downstream.sh
+++ b/id_downstream.sh
@@ -5,6 +5,17 @@ LINEAR_MEDMNIST_PATH=scripts/linear/medmnist/
 MODEL_ROOT_DIR=/graphics/scratch2/students/saritas/trained_models   # CHANGE
 CHECKPOINTS_DIR=/graphics/scratch2/students/saritas/checkpoints     # CHANGE
 
+# Cease operation if CHECKPOINTS_DIR string is empty - prevent accidental deletion of files
+if [ -z "$CHECKPOINTS_DIR" ]; then
+    echo "CHECKPOINTS_DIR is empty. Ceasing operation."
+    exit 1
+fi
+
+# Print find command output
+echo "Beginning downstream task on the following checkpoints:"
+find $MODEL_ROOT_DIR -type f -name "*best_val_acc1.ckpt"
+echo -e "\n"
+
 # Recursively search for models ending with 'best_val_acc1.ckpt'
 find $MODEL_ROOT_DIR -type f -name "*best_val_acc1.ckpt" | while read -r model_path; do
 

--- a/main_linear.py
+++ b/main_linear.py
@@ -25,7 +25,7 @@ from torch.utils import data
 import hydra
 import torch
 import torch.nn as nn
-from lightning.pytorch import Trainer
+from lightning.pytorch import Trainer, seed_everything
 from lightning.pytorch.callbacks import LearningRateMonitor
 from lightning.pytorch.loggers import WandbLogger
 from lightning.pytorch.strategies.ddp import DDPStrategy
@@ -86,6 +86,8 @@ def main(cfg: DictConfig):
     OmegaConf.set_struct(cfg, False)
     cfg = parse_cfg(cfg)
 
+    seed_everything(cfg.seed)
+    
     backbone_model = BaseMethod._BACKBONES[cfg.backbone.name]
 
     # initialize backbone

--- a/scripts/linear/medmnist/data/organsmnist.yaml
+++ b/scripts/linear/medmnist/data/organsmnist.yaml
@@ -1,5 +1,5 @@
 
-dataset: "organcmnist"
+dataset: "organsmnist"
 root: "/graphics/scratch2/students/kargibo/dataset/medmnist"
 num_workers: 8
 image_size: 64


### PR DESCRIPTION
* Fix typo in linear organs config: organc --> organs
* Add seed_everything in main_linear as in main_solo.
  * Note that current linear configs do not have a seed field. This will default to [cfg.seed=5](https://github.com/KarahanS/Self-Supervised-Learning-for-Medical-Image-Analysis/blob/00fe60d7334daa3a78f0b75e6c7b1ee00f0955aa/src/args/linear.py#L98)
* Sanity check in downstream runner to prevent accidental deletions via `rm rf /*`